### PR TITLE
Update SolutionsDocument.tex

### DIFF
--- a/SolutionsDocument.tex
+++ b/SolutionsDocument.tex
@@ -185,7 +185,7 @@ so we're done again}
 
 \problem[10]{2015 IMO, Q1}{Cg6}{We say that a finite set $S$ of points in the plane is \textit{balanced} if, for any two different points $A$ and $B$ in $S$, there is a point $C$ in $S$ such that $AC = BC$. We say that $S$ is \emph{centre-free} if for any three different points $A, B$ and $C$ in $S$, there is no point $P$ in $S$ such that $PA = PB = PC$. \begin{enumerate} \item Show that for all integers $n \geq 3$, there exists a balanced set consisting of $n$ points.\item Determine all integers $n \geq 3$ for which there exists a balanced centre-free set consisting of $n$ points.\end{enumerate}}
 
-\problem[11]{2015 IMO, Q2}{A9}{Let $\mathbb{R}$ be the set of real numbers. Determine all functions $f : \mathbb{R} \to \mathbb{R}$ such that, for all real numbers $x$ and $y$, \[f(f(x)f(y)) + f(x + y) = f(xy).\]}
+\problem[11]{2015 IMO, Q2}{(FE)A9}{Let $\mathbb{R}$ be the set of real numbers. Determine all functions $f : \mathbb{R} \to \mathbb{R}$ such that, for all real numbers $x$ and $y$, \[f(f(x)f(y)) + f(x + y) = f(xy).\]}
 
 \problem[12]{2013 BMO2, Q4}{NG5}{Suppose that $ABCD$ is a square and that $P$ is a point which is on the circle inscribed in the square. Determine whether or not it is possible that $PA$, $PB$, $PC$, $PD$ and $AB$ are all integers.}
 
@@ -201,7 +201,7 @@ so we're done again}
 
 \problem[18]{2015/16 BMO1, Q6}{N5}{A positive integer is called \emph{charming} if it is equal to 2 or is of the form $3^i5^j$ where $i$ and $j$ are non-negative integers. Prove that every positive integer can be written as a sum of different charming integers.}
 
-\problem[19]{2004 Swedish MO (44th), Final Round, Q3}{A(FE)3}{Find all functions $f$ satisfying $f(x)+x f(1-x) = x^2$ for all real $x$.}
+\problem[19]{2004 Swedish MO (44th), Final Round, Q3}{(FE)A3}{Find all functions $f$ satisfying $f(x)+x f(1-x) = x^2$ for all real $x$.}
 
 \problem[20]{2018 IMO Shortlist, C2}{C5}{Let $n$ be a positive integer. Define a \emph{chameleon} to be any sequence of $3n$ letters, with exactly $n$ occurrences of each of the letters $a$, $b$, and $c$. Define a \emph{swap} to be the transposition of two adjacent letters in a chameleon. Prove that for any chameleon $X$, there exists a chameleon $Y$ such that $X$ cannot be changed to $Y$ using fewer than $3n^2/2$ swaps.}
 
@@ -209,15 +209,15 @@ so we're done again}
 
 \problem[22]{2004 Swedish MO (44th), Final Round, Q4}{Cg6}{A square with integer side length $n \geq 3$ is divided into $n^2$ unit squares, and $n-1$ lines are drawn so that each square's interior is cut by at least one line. \begin{enumerate} \item[(a)] Give an example of such a configuration for some $n$. \item[(b)] Show that some two of the lines must meet inside the square \end{enumerate}}
 
-\problem[23]{2018 Euclid Contest, Q10 (adapted)}{A5-6}{In an infinite grid with two rows, each row continues to the left and right without bound. Each cell contains a positive real number. Prove that if each cell is the average of its three neighbours, then all the numbers in the grid are equal.}
+\problem[23]{2018 Euclid Contest, Q10 (adapted)}{A5-A6}{In an infinite grid with two rows, each row continues to the left and right without bound. Each cell contains a positive real number. Prove that if each cell is the average of its three neighbours, then all the numbers in the grid are equal.}
 
 \problem[24]{2015/16 BMO1, Q2}{G2}{Let $ABCD$ be a cyclic quadrilateral and let the lines $CD$ and $BA$ meet at $E$. The line through $D$ which is tangent to the circle $ADE$ meets the line $CB$ at $F$. Prove that the triangle $CDF$ is isosceles.}
 
-\problem[25]{1993 IMO (34th), Q1}{A(Poly)5}{Let $n > 1$ be an integer and let $f(x) = x^n + 5x^{n-1} + 3$. Prove that there do not exist polynomials $g(x),h(x)$, each having integer coefficients and degree at least one, such that $f(x) = g(x)h(x)$.}
+\problem[25]{1993 IMO (34th), Q1}{(Poly)A5}{Let $n > 1$ be an integer and let $f(x) = x^n + 5x^{n-1} + 3$. Prove that there do not exist polynomials $g(x),h(x)$, each having integer coefficients and degree at least one, such that $f(x) = g(x)h(x)$.}
 
 \problem[26]{2000 Dutch MO, Second Round, Q5 of 5}{C4}{Consider an infinite strip of unit squares numbered $1, 2, 3, \dots$. A pawn starting on one of these squares can, at each step, move between squares numbered $n$, $2n$, and $3n+1$. Show that the pawn will be able to reach the square $1$ after finitely many steps.}
 
-\problem[27]{2005 Canadian MO (37th), Q2 of 5}{A/N4}{Let ((a,b,c)) be a Pythagorean triple, i.e.\ a triplet of positive integers with ($a^2$ + $b^2$ = $c^2$). \begin{enumerate} \item[(a)] Prove that $(\left( \frac{c}{a} + \frac{b}{a} \right) ^2 > 8)$. \item[(b)] Prove that there are no integers $n$ and Pythagorean triples $(a,b,c)$ satisfying $\left( \frac{c}{a} + \frac{b}{a} \right) ^2 = n$. \end{enumerate}}
+\problem[27]{2005 Canadian MO (37th), Q2 of 5}{A4/N4}{Let ((a,b,c)) be a Pythagorean triple, i.e.\ a triplet of positive integers with ($a^2$ + $b^2$ = $c^2$). \begin{enumerate} \item[(a)] Prove that $(\left( \frac{c}{a} + \frac{b}{a} \right) ^2 > 8)$. \item[(b)] Prove that there are no integers $n$ and Pythagorean triples $(a,b,c)$ satisfying $\left( \frac{c}{a} + \frac{b}{a} \right) ^2 = n$. \end{enumerate}}
 
 \problem[28]{2016 IMO (57th), Q1}{G6}{Triangle $BCF$ has a right angle at $B$. Let $A$ be the point on line $CF$ such that $FA=FB$ and $F$ lies between $A$ and $C$. Point $D$ is chosen so that $DA=DC$ and $AC$ is the bisector of $\angle{DAB}$. Point $E$ is chosen so that $EA=ED$ and $AD$ is the bisector of $\angle{EAC}$. Let $M$ be the midpoint of $CF$. Let $X$ be the point such that $AMXE$ is a parallelogram (where $AM \parallel EX$ and $AE \parallel MX$). Prove that $BD,FX$ and $ME$ are concurrent.}
 


### PR DESCRIPTION
changed subtag format from, e.g., A(FE)5 to (FE)A5. Also changed other tags for searchability - such as A5-6 to A5-A6, and A/N4 to A4/N4.